### PR TITLE
Instead of a 500, Use Empty Schedule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v3.1
+VERSION=v3.3-SNAPSHOT
 REGISTRY=gcr.io
 PROJECT_ID=kubecost1
 APPNAME=kubecost-turndown

--- a/turndown/turndownendpoints.go
+++ b/turndown/turndownendpoints.go
@@ -46,7 +46,7 @@ func (te *TurndownEndpoints) HandleStartSchedule(w http.ResponseWriter, r *http.
 	if r.Method == http.MethodGet {
 		schedule := te.scheduler.GetSchedule()
 		if schedule == nil {
-			w.Write(wrapData(nil, fmt.Errorf("No schedule available.")))
+			w.Write(wrapData(struct{}{}, nil))
 			return
 		}
 


### PR DESCRIPTION
Have the schedule endpoint return an empty schedule if a schedule doesn't exist. 