### PR TITLE
Label Passthrough on Strategy

### DIFF
--- a/cmd/turndown/main.go
+++ b/cmd/turndown/main.go
@@ -93,11 +93,13 @@ func runTurndownResourceController(kubeClient kubernetes.Interface, tdClient cli
 // For now, we'll choose our strategy based on the provider, but functionally, there is
 // no dependency.
 func strategyForProvider(c kubernetes.Interface, p provider.TurndownProvider) (strategy.TurndownStrategy, error) {
+	m := make(map[string]string)
+
 	switch v := p.(type) {
 	case *provider.GKEProvider:
-		return strategy.NewMasterlessTurndownStrategy(c, p), nil
+		return strategy.NewMasterlessTurndownStrategy(c, p, m), nil
 	case *provider.EKSProvider:
-		return strategy.NewMasterlessTurndownStrategy(c, p), nil
+		return strategy.NewMasterlessTurndownStrategy(c, p, m), nil
 	case *provider.AWSProvider:
 		return strategy.NewStandardTurndownStrategy(c, p), nil
 	default:

--- a/pkg/turndown/provider/awsprovider.go
+++ b/pkg/turndown/provider/awsprovider.go
@@ -42,12 +42,10 @@ func (p *AWSProvider) IsTurndownNodePool() bool {
 	return p.clusterProvider.IsNodePool(AWSTurndownPoolName)
 }
 
-func (p *AWSProvider) CreateSingletonNodePool() error {
+func (p *AWSProvider) CreateSingletonNodePool(labels map[string]string) error {
 	ctx := context.TODO()
 
-	return p.clusterProvider.CreateNodePool(ctx, AWSTurndownPoolName, "t2.small", 1, "gp2", 10, map[string]string{
-		TurndownNodeLabel: "true",
-	})
+	return p.clusterProvider.CreateNodePool(ctx, AWSTurndownPoolName, "t2.small", 1, "gp2", 10, toTurndownNodePoolLabels(labels))
 }
 
 func (p *AWSProvider) GetPoolID(node *v1.Node) string {

--- a/pkg/turndown/provider/eksprovider.go
+++ b/pkg/turndown/provider/eksprovider.go
@@ -38,12 +38,10 @@ func (p *EKSProvider) IsTurndownNodePool() bool {
 	return p.clusterProvider.IsNodePool(EKSTurndownPoolName)
 }
 
-func (p *EKSProvider) CreateSingletonNodePool() error {
+func (p *EKSProvider) CreateSingletonNodePool(labels map[string]string) error {
 	ctx := context.TODO()
 
-	return p.clusterProvider.CreateNodePool(ctx, EKSTurndownPoolName, "t2.small", 1, "gp2", 10, map[string]string{
-		TurndownNodeLabel: "true",
-	})
+	return p.clusterProvider.CreateNodePool(ctx, EKSTurndownPoolName, "t2.small", 1, "gp2", 10, toTurndownNodePoolLabels(labels))
 }
 
 func (p *EKSProvider) GetPoolID(node *v1.Node) string {

--- a/pkg/turndown/provider/gkeprovider.go
+++ b/pkg/turndown/provider/gkeprovider.go
@@ -38,12 +38,10 @@ func (p *GKEProvider) IsTurndownNodePool() bool {
 	return p.clusterProvider.IsNodePool(GKETurndownPoolName)
 }
 
-func (p *GKEProvider) CreateSingletonNodePool() error {
+func (p *GKEProvider) CreateSingletonNodePool(labels map[string]string) error {
 	ctx := context.TODO()
 
-	return p.clusterProvider.CreateNodePool(ctx, GKETurndownPoolName, "g1-small", 1, "pd-standard", 10, map[string]string{
-		TurndownNodeLabel: "true",
-	})
+	return p.clusterProvider.CreateNodePool(ctx, GKETurndownPoolName, "g1-small", 1, "pd-standard", 10, toTurndownNodePoolLabels(labels))
 }
 
 func (p *GKEProvider) GetPoolID(node *v1.Node) string {

--- a/pkg/turndown/strategy/standard.go
+++ b/pkg/turndown/strategy/standard.go
@@ -65,7 +65,7 @@ func (ktdm *StandardTurndownStrategy) CreateOrGetHostNode() (*v1.Node, error) {
 	masterNode := &nodeList.Items[0]
 
 	// Patch and get the updated node
-	return patcher.UpdateNodeLabel(ktdm.client, *masterNode, "cluster-turndown-node", "true")
+	return patcher.UpdateNodeLabel(ktdm.client, *masterNode, provider.TurndownNodeLabel, "true")
 }
 
 func (sts *StandardTurndownStrategy) UpdateDNS() error {
@@ -129,7 +129,7 @@ func (sts *StandardTurndownStrategy) ReverseHostNode() error {
 	masterNode := &nodeList.Items[0]
 
 	// Patch and get the updated node
-	_, err = patcher.DeleteNodeLabel(sts.client, *masterNode, "cluster-turndown-node")
+	_, err = patcher.DeleteNodeLabel(sts.client, *masterNode, provider.TurndownNodeLabel)
 
 	dns, err := sts.client.AppsV1().Deployments("kube-system").Get("kube-dns", metav1.GetOptions{})
 	if err != nil {

--- a/pkg/turndown/turndown.go
+++ b/pkg/turndown/turndown.go
@@ -75,7 +75,7 @@ func (ktdm *KubernetesTurndownManager) IsScaledDown() bool {
 
 func (ktdm *KubernetesTurndownManager) IsRunningOnTurndownNode() (bool, error) {
 	nodeList, err := ktdm.client.CoreV1().Nodes().List(metav1.ListOptions{
-		LabelSelector: "cluster-turndown-node=true",
+		LabelSelector: provider.TurndownNodeLabelSelector,
 	})
 	if err != nil {
 		return false, err
@@ -136,7 +136,7 @@ func (ktdm *KubernetesTurndownManager) PrepareTurndownEnvironment() error {
 			Operator: v1.TolerationOpExists,
 		})
 		d.Spec.Template.Spec.NodeSelector = map[string]string{
-			"cluster-turndown-node": "true",
+			provider.TurndownNodeLabel: "true",
 		}
 		return nil
 	})


### PR DESCRIPTION
* Allow label set to be passed to the masterless strategy to be used in singleton node creation. 
* Move turndown magic strings to const values.