### PR TITLE
Add missing --project flag

### DIFF
--- a/scripts/gke-create-service-key.sh
+++ b/scripts/gke-create-service-key.sh
@@ -74,7 +74,7 @@ gcloud iam roles create cluster.turndown.v2 --project $PROJECT_ID --file cluster
 rm -f cluster-turndown-role.yaml
 
 # Create a new service account with the provided inputs and assign the new role
-gcloud iam service-accounts create $SERVICE_ACCOUNT_NAME --display-name $SERVICE_ACCOUNT_NAME --format json && \
+gcloud iam service-accounts create --project $PROJECT_ID $SERVICE_ACCOUNT_NAME --display-name $SERVICE_ACCOUNT_NAME --format json && \
     gcloud projects add-iam-policy-binding $PROJECT_ID --member serviceAccount:$SERVICE_ACCOUNT_NAME@$PROJECT_ID.iam.gserviceaccount.com --role projects/$PROJECT_ID/roles/cluster.turndown.v2 && \
     gcloud iam service-accounts keys create $DIR/service-key.json --iam-account $SERVICE_ACCOUNT_NAME@$PROJECT_ID.iam.gserviceaccount.com
 


### PR DESCRIPTION
One of the gcloud commands in the service key-creation script was missing
the `--project` flag, meaning it could fail (when no gcloud default project is set)
or try to perform an operation on the wrong project (when the default is different
then the user-provided arg). Fixed by adding this flag. Tested on a machine with
no default project set, new behavior is correct.