### PR TITLE
Update to v1.3.0

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,3 +8,11 @@ bash generate.sh
 ```
 
 The script is based on https://github.com/kubernetes/sample-controller, specifically https://github.com/kubernetes/sample-controller/blob/master/hack/update-codegen.sh.
+
+## Cutting a release
+
+1. Update the `VERSION` in the Makefile
+2. Update the image version to match in artifacts/cluster-turndown-full.yaml
+3. Build and push the new image to GCR (`make release`)
+4. Merge the changes
+5. Tag a new release off of develop for the new version

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -11,8 +11,7 @@ The script is based on https://github.com/kubernetes/sample-controller, specific
 
 ## Cutting a release
 
-1. Update the `VERSION` in the Makefile
-2. Update the image version to match in artifacts/cluster-turndown-full.yaml
-3. Build and push the new image to GCR (`make release`)
-4. Merge the changes
-5. Tag a new release off of develop for the new version
+1. Call `update-version.sh VERSION`, e.g. `./update-version.sh 1.3.0`
+2. Build and push the new image to GCR (`make release`)
+3. Merge the changes
+4. Tag a new release off of develop for the new version

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.2.2
+VERSION=1.3.0
 REGISTRY=gcr.io
 PROJECT_ID=kubecost1
 APPNAME=cluster-turndown

--- a/artifacts/cluster-turndown-full.yaml
+++ b/artifacts/cluster-turndown-full.yaml
@@ -179,7 +179,7 @@ spec:
     spec:
       containers:
       - name: cluster-turndown
-        image: gcr.io/kubecost1/cluster-turndown:1.2.2
+        image: gcr.io/kubecost1/cluster-turndown:1.3.0
         volumeMounts:
         - name: turndown-keys
           mountPath: /var/keys


### PR DESCRIPTION
Updates image version to v1.3.0 after the merge of https://github.com/kubecost/cluster-turndown/pull/37. This will let me import cluster-turndown in cluster-controller with a proper version instead of a commit hash :)

I made sure to `make release` for v1.3.0 and as soon as this PR is merged I'll add a tag for v1.3.0 on the code!