### PR TITLE
Update  command to start cluster-turdown pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ $ kubectl create secret generic cluster-turndown-service-key -n turndown --from-
 After completing setup, run the following command to get the `cluster-turndown` pod running on your cluster:
 
 ```bash
-$ kubectl apply -f https://github.com/kubecost/cluster-turndown/releases/latest/download/cluster-turndown-full.yaml
+$ kubectl apply -f artifacts/cluster-turndown-full.yaml
 ```
 
 In this yaml, you'll find the definitions for the following:


### PR DESCRIPTION
`kubectl apply -f https://github.com/kubecost/cluster-turndown/releases/latest/download/cluster-turndown-full.yaml` failed with error error: unable to read URL "https://github.com/kubecost/cluster-turndown/releases/latest/download/cluster-turndown-full.yaml", server reported 404 Not Found, status code=404 . 

So I suggest to add local path as above in the documentation, the repo should be cloned.