### PR TITLE
Upgrade turndownschedules CRD to apiextensions v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,12 @@ $ kubectl get pods -l app=cluster-turndown -n turndown
 Cluster Turndown uses a Kubernetes Custom Resource Definition to create schedules. There is an example resource located at `artifacts/example-schedule.yaml`:
 
 ```yaml
-apiVersion: kubecost.k8s.io/v1alpha1
+apiVersion: kubecost.com/v1alpha1
 kind: TurndownSchedule
 metadata:
   name: example-schedule
   finalizers:
-  - "finalizer.kubecost.k8s.io"
+  - "finalizer.kubecost.com"
 spec:
   start: 2020-03-12T00:00:00Z
   end: 2020-03-12T12:00:00Z
@@ -201,19 +201,19 @@ Details regarding the status of the turndown schedule can be found by outputting
 ```bash
 $ kubectl get tds example-schedule -o yaml
 
-apiVersion: kubecost.k8s.io/v1alpha1
+apiVersion: kubecost.com/v1alpha1
 kind: TurndownSchedule
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"kubecost.k8s.io/v1alpha1","kind":"TurndownSchedule","metadata":{"annotations":{},"finalizers":["finalizer.kubecost.k8s.io"],"name":"example-schedule"},"spec":{"end":"2020-03-17T00:35:00Z","repeat":"daily","start":"2020-03-17T00:20:00Z"}}
+      {"apiVersion":"kubecost.com/v1alpha1","kind":"TurndownSchedule","metadata":{"annotations":{},"finalizers":["finalizer.kubecost.com"],"name":"example-schedule"},"spec":{"end":"2020-03-17T00:35:00Z","repeat":"daily","start":"2020-03-17T00:20:00Z"}}
   creationTimestamp: "2020-03-17T00:18:39Z"
   finalizers:
-  - finalizer.kubecost.k8s.io
+  - finalizer.kubecost.com
   generation: 1
   name: example-schedule
   resourceVersion: "33573"
-  selfLink: /apis/kubecost.k8s.io/v1alpha1/turndownschedules/example-schedule
+  selfLink: /apis/kubecost.com/v1alpha1/turndownschedules/example-schedule
   uid: d9b16aed-67e4-11ea-b591-42010a8e0075
 spec:
   end: "2020-03-17T00:35:00Z"

--- a/artifacts/cluster-turndown-full.yaml
+++ b/artifacts/cluster-turndown-full.yaml
@@ -14,7 +14,7 @@ metadata:
     app: cluster-turndown
 rules:
   - apiGroups:
-      - kubecost.k8s.io
+      - kubecost.com
     resources:
       - turndownschedules
       - turndownschedules/status
@@ -204,13 +204,12 @@ spec:
           secretName: cluster-turndown-service-key
 ---
 # TurndownSchedule Custom Resource Definition for persistence
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: turndownschedules.kubecost.k8s.io
+  name: turndownschedules.kubecost.com
 spec:
-  group: kubecost.k8s.io
-  version: v1alpha1
+  group: kubecost.com
   names:
     kind: TurndownSchedule
     singular: turndownschedule
@@ -219,33 +218,38 @@ spec:
     - td
     - tds
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
           type: object
           properties:
-            start: 
-              type: string
-              format: date-time
-            end:
-              type: string
-              format: date-time
-            repeat: 
-              type: string
-              enum: [none, daily, weekly]
-  additionalPrinterColumns:
-  - name: State
-    type: string
-    description: The state of the turndownschedule 
-    JSONPath: .status.state
-  - name: Next Turndown
-    type: string
-    description: The next turndown date-time
-    JSONPath: .status.nextScaleDownTime
-  - name: Next Turn Up
-    type: string
-    description: The next turn up date-time
-    JSONPath: .status.nextScaleUpTime
+            spec:
+              type: object
+              properties:
+                start:
+                  type: string
+                  format: date-time
+                end:
+                  type: string
+                  format: date-time
+                repeat:
+                  type: string
+                  enum: [none, daily, weekly]
+      additionalPrinterColumns:
+      - name: State
+        type: string
+        description: The state of the turndownschedule
+        jsonPath: .status.state
+      - name: Next Turndown
+        type: string
+        description: The next turndown date-time
+        jsonPath: .status.nextScaleDownTime
+      - name: Next Turn Up
+        type: string
+        description: The next turn up date-time
+        jsonPath: .status.nextScaleUpTime

--- a/artifacts/example-schedule.yaml
+++ b/artifacts/example-schedule.yaml
@@ -1,9 +1,9 @@
-apiVersion: kubecost.k8s.io/v1alpha1
+apiVersion: kubecost.com/v1alpha1
 kind: TurndownSchedule
 metadata:
   name: example-schedule
   finalizers:
-  - "finalizer.kubecost.k8s.io"
+  - "finalizer.kubecost.com"
 spec:
   start: 2020-03-12T00:00:00Z
   end: 2020-03-12T12:00:00Z

--- a/artifacts/turndown-schedule-definition.yaml
+++ b/artifacts/turndown-schedule-definition.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: turndownschedules.kubecost.k8s.io
+  name: turndownschedules.kubecost.com
 spec:
-  group: kubecost.k8s.io
-  version: v1alpha1
+  group: kubecost.com
   names:
     kind: TurndownSchedule
     singular: turndownschedule
@@ -13,34 +12,38 @@ spec:
     - td
     - tds
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
           type: object
           properties:
-            start: 
-              type: string
-              format: date-time
-            end:
-              type: string
-              format: date-time
-            repeat: 
-              type: string
-              enum: [none, daily, weekly]
-  additionalPrinterColumns:
-  - name: State
-    type: string
-    description: The state of the turndownschedule 
-    JSONPath: .status.state
-  - name: Next Turndown
-    type: string
-    description: The next turndown date-time
-    JSONPath: .status.nextScaleDownTime
-  - name: Next Turn Up
-    type: string
-    description: The next turn up date-time
-    JSONPath: .status.nextScaleUpTime
+            spec:
+              type: object
+              properties:
+                start:
+                  type: string
+                  format: date-time
+                end:
+                  type: string
+                  format: date-time
+                repeat:
+                  type: string
+                  enum: [none, daily, weekly]
+      additionalPrinterColumns:
+      - name: State
+        type: string
+        description: The state of the turndownschedule
+        jsonPath: .status.state
+      - name: Next Turndown
+        type: string
+        description: The next turndown date-time
+        jsonPath: .status.nextScaleDownTime
+      - name: Next Turn Up
+        type: string
+        description: The next turn up date-time
+        jsonPath: .status.nextScaleUpTime

--- a/pkg/apis/turndownschedule/register.go
+++ b/pkg/apis/turndownschedule/register.go
@@ -1,5 +1,5 @@
 package turndownschedule
 
 const (
-	GroupName = "kubecost.k8s.io"
+	GroupName = "kubecost.com"
 )

--- a/pkg/apis/turndownschedule/v1alpha1/doc.go
+++ b/pkg/apis/turndownschedule/v1alpha1/doc.go
@@ -1,7 +1,7 @@
 // +k8s:deepcopy-gen=package,register
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:openapi-gen=true
-// +groupName=kubecost.k8s.io
+// +groupName=kubecost.com
 
 // Package v1alpha1 is the v1alpha1 version of the API.
 package v1alpha1

--- a/pkg/generated/clientset/versioned/typed/turndownschedule/v1alpha1/fake/fake_turndownschedule.go
+++ b/pkg/generated/clientset/versioned/typed/turndownschedule/v1alpha1/fake/fake_turndownschedule.go
@@ -20,9 +20,9 @@ type FakeTurndownSchedules struct {
 	Fake *FakeKubecostV1alpha1
 }
 
-var turndownschedulesResource = schema.GroupVersionResource{Group: "kubecost.k8s.io", Version: "v1alpha1", Resource: "turndownschedules"}
+var turndownschedulesResource = schema.GroupVersionResource{Group: "kubecost.com", Version: "v1alpha1", Resource: "turndownschedules"}
 
-var turndownschedulesKind = schema.GroupVersionKind{Group: "kubecost.k8s.io", Version: "v1alpha1", Kind: "TurndownSchedule"}
+var turndownschedulesKind = schema.GroupVersionKind{Group: "kubecost.com", Version: "v1alpha1", Kind: "TurndownSchedule"}
 
 // Get takes name of the turndownSchedule, and returns the corresponding turndownSchedule object, and an error if there is any.
 func (c *FakeTurndownSchedules) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.TurndownSchedule, err error) {

--- a/pkg/generated/clientset/versioned/typed/turndownschedule/v1alpha1/turndownschedule_client.go
+++ b/pkg/generated/clientset/versioned/typed/turndownschedule/v1alpha1/turndownschedule_client.go
@@ -14,7 +14,7 @@ type KubecostV1alpha1Interface interface {
 	TurndownSchedulesGetter
 }
 
-// KubecostV1alpha1Client is used to interact with features provided by the kubecost.k8s.io group.
+// KubecostV1alpha1Client is used to interact with features provided by the kubecost.com group.
 type KubecostV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/pkg/generated/informers/externalversions/generic.go
+++ b/pkg/generated/informers/externalversions/generic.go
@@ -37,7 +37,7 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=kubecost.k8s.io, Version=v1alpha1
+	// Group=kubecost.com, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithResource("turndownschedules"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Kubecost().V1alpha1().TurndownSchedules().Informer()}, nil
 

--- a/pkg/turndown/schedulecontroller.go
+++ b/pkg/turndown/schedulecontroller.go
@@ -41,7 +41,7 @@ const (
 	// due to an existing turndown schedule.
 	ErrAlreadyScheduled = "ErrAlreadyScheduled"
 
-	TurndownScheduleFinalizer = "finalizer.kubecost.k8s.io"
+	TurndownScheduleFinalizer = "finalizer.kubecost.com"
 
 	ScheduleStateSuccess   = "ScheduleSuccess"
 	ScheduleStateFailed    = "ScheduleFailed"


### PR DESCRIPTION
This PR addresses https://github.com/kubecost/cluster-turndown/issues/40.

## Changes
`apiextensions.k8s.io/v1beta1` is removed as of K8s v1.22 [1], so all CRDs
have to be updated to `apiextensions.k8s.io/v1`. This commit does the
upgrade for the `turndownschedule` CRD.

As part of the API updates, K8s is enforcing things grouped under
`*.k8s.io` to be approved [2] because they are actually supposed to be
Kubernetes community-managed APIs [3]. So this commit also changes the
CRD from:

`turndownschedules.kubecost.k8s.io`
to
`turndownschedules.kubecost.com`

This is in-line with K8s rules and links to our main domain.

## Testing
Tested by applying `cluster-turndown-full.yaml` and `example-schedule.yaml`
successfully (with updated container image from this commit) as instructed
by the README.

## Notes
We did a similar change in https://github.com/kubecost/cost-analyzer-helm-chart/pull/1429 but didn't do all of the necessary steps, like changing the CRD group to `kubecost.com` and similar changes. Once this PR has been approved, merged, and a new version of cluster-turndown is released, we'll have to update cluster-controller (because of the regenerated code for `turndownschedules.kubecost.com`) and the turndownschedule CRD in the main Kubecost Helm chart.


[1] https://cloud.google.com/kubernetes-engine/docs/deprecations/apis-1-22
[2] https://github.com/kubernetes/enhancements/pull/1111
[3] https://github.com/kubernetes/enhancements/pull/1111#issuecomment-507834574