### PR TITLE
Update cluster-turndown to v2.0.0

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,5 +1,19 @@
 # Development
 
+## Building development images
+
+```sh
+export TDTAG="dockerregistry.example.com/cluster-turndown:X.Y.Z"
+docker build -t "${TDTAG}" .
+docker push "${TDTAG}"
+
+# Then update the image in your cluster
+kubectl set image \
+    -n turndown \
+    deployment/cluster-turndown \
+    cluster-turndown="${TDTAG}"
+```
+
 ## Generating turndown schedule CRD code
 
 To re-generate the code for the defined CRDs, do the following:
@@ -11,8 +25,8 @@ The script is based on https://github.com/kubernetes/sample-controller, specific
 
 ## Cutting a release
 
-1. Call `update-version.sh VERSION`, e.g. `./update-version.sh 1.3.0`
-2. Build and push the new image to GCR (`make release`)
+1. Call `update-version.sh VERSION`, e.g. `./update-version.sh X.Y.Z`
+2. Build and push the new image to GCR (`make VERSION=X.Y.Z release`)
 3. Merge the changes
 4. Tag a new release off of `develop` for the new version
 5. Manually upload `artifacts/cluster-turndown-full.yaml` and `scripts/gke-create-service-key.sh` to the GitHub Release created by the tag

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.3.0
+VERSION=2.0.0
 REGISTRY=gcr.io
 PROJECT_ID=kubecost1
 APPNAME=cluster-turndown

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Cluster Turndown
 Cluster Turndown is an automated scaledown and scaleup of a Kubernetes cluster's backing nodes based on a custom schedule and turndown criteria. This feature can be used to reduce spend during down hours and/or reduce surface area for security reasons. The most common use case is to scale non-prod environments (e.g. dev clusters) to zero during off hours. The project currently suppoorts clusters on GKE, EKS, and kops on AWS. 
 
+> :warning: If you are upgrading from a pre-2.0.0 version of cluster-turndown, you will have to migrate your custom resources. `turndownschedules.kubecost.k8s.io` has been changed to `turndownschedules.kubecost.com` and `finalizers.kubecost.k8s.io` has been changed to `finalizers.kubecost.com`. See https://github.com/kubecost/cluster-turndown/pull/44 for an explanation. :warning:
+
 **Note: Cluster Turndown is currently in _ALPHA_**
 
 ### GKE Setup

--- a/artifacts/cluster-turndown-full.yaml
+++ b/artifacts/cluster-turndown-full.yaml
@@ -179,7 +179,7 @@ spec:
     spec:
       containers:
       - name: cluster-turndown
-        image: gcr.io/kubecost1/cluster-turndown:1.3.0
+        image: gcr.io/kubecost1/cluster-turndown:2.0.0
         volumeMounts:
         - name: turndown-keys
           mountPath: /var/keys


### PR DESCRIPTION
Changes in #44 are breaking, necessitating a major version bump. See that PR and the README changes in this PR.

I also included some extra notes in DEVELOPMENT.md.

Images for 2.0.0 have been built and pushed to gcr.io/kubecost1. I ran `k apply -f ./artifacts/cluster-turndown-full.yaml` to ensure a correct deployment. A Git tag and GitHub release will follow.