### PR TITLE
Add auto-label-new-issues workflow

### DIFF
--- a/.github/workflows/auto_label_issues.yml
+++ b/.github/workflows/auto_label_issues.yml
@@ -1,0 +1,14 @@
+name: auto-label-new-issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  automate-issues-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label new issues with 'needs-triage'
+        uses: andymckay/labeler@1.0.4
+        with:
+          add-labels: "needs-triage"


### PR DESCRIPTION
Adds workflow to auto-label all newly-opened issues with "needs-triage" label.