### PR TITLE
Add schema for CRD status

### DIFF
--- a/artifacts/cluster-turndown-full.yaml
+++ b/artifacts/cluster-turndown-full.yaml
@@ -240,6 +240,34 @@ spec:
                 repeat:
                   type: string
                   enum: [none, daily, weekly]
+            status:
+              type: object
+              properties:
+                state:
+                  type: string
+                lastUpdated:
+                  format: date-time
+                  type: string
+                current:
+                  type: string
+                scaleDownId:
+                  type: string
+                nextScaleDownTime:
+                  format: date-time
+                  type: string
+                scaleDownMetadata:
+                  additionalProperties:
+                    type: string
+                  type: object
+                scaleUpID:
+                  type: string
+                nextScaleUpTime:
+                  format: date-time
+                  type: string
+                scaleUpMetadata:
+                  additionalProperties:
+                    type: string
+                  type: object
       additionalPrinterColumns:
       - name: State
         type: string

--- a/artifacts/turndown-schedule-definition.yaml
+++ b/artifacts/turndown-schedule-definition.yaml
@@ -34,6 +34,34 @@ spec:
                 repeat:
                   type: string
                   enum: [none, daily, weekly]
+            status:
+              type: object
+              properties:
+                state:
+                  type: string
+                lastUpdated:
+                  format: date-time
+                  type: string
+                current:
+                  type: string
+                scaleDownId:
+                  type: string
+                nextScaleDownTime:
+                  format: date-time
+                  type: string
+                scaleDownMetadata:
+                  additionalProperties:
+                    type: string
+                  type: object
+                scaleUpID:
+                  type: string
+                nextScaleUpTime:
+                  format: date-time
+                  type: string
+                scaleUpMetadata:
+                  additionalProperties:
+                    type: string
+                  type: object
       additionalPrinterColumns:
       - name: State
         type: string


### PR DESCRIPTION
Fixes a bug where the CR (turndownschedule) status would never be updated because calls to UpdateStatus were no-ops. With the schema, they are no longer no-ops.

Tested via KC Helm chart changes which are identical to this PR: https://github.com/kubecost/cost-analyzer-helm-chart/pull/2209