### PR TITLE
prevent encoded nil in endpoint response

### DIFF
--- a/pkg/turndown/turndownendpoints.go
+++ b/pkg/turndown/turndownendpoints.go
@@ -49,6 +49,10 @@ func (te *TurndownEndpoints) HandleStartSchedule(w http.ResponseWriter, r *http.
 
 	if r.Method == http.MethodGet {
 		schedule := te.scheduler.GetSchedule()
+		if schedule == nil {
+			protocol.WriteData(w, schedule)
+			return
+		}
 
 		marshaled, err := json.Marshal(schedule)
 		if err != nil {

--- a/pkg/turndown/turndownendpoints.go
+++ b/pkg/turndown/turndownendpoints.go
@@ -49,18 +49,8 @@ func (te *TurndownEndpoints) HandleStartSchedule(w http.ResponseWriter, r *http.
 
 	if r.Method == http.MethodGet {
 		schedule := te.scheduler.GetSchedule()
-		if schedule == nil {
-			protocol.WriteData(w, schedule)
-			return
-		}
 
-		marshaled, err := json.Marshal(schedule)
-		if err != nil {
-			protocol.WriteError(w, protocol.InternalServerError(fmt.Sprintf("Failed to marshal result: %s", err)))
-			return
-		}
-
-		protocol.WriteData(w, marshaled)
+		protocol.WriteData(w, schedule)
 		return
 	}
 


### PR DESCRIPTION
Return early if the schedule returned is nil